### PR TITLE
Change e2e tests to re-try CR updates

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -19,7 +19,7 @@ login_cluster(){
 ## cleanup : Delete generated resources that are not bound to a test namespace.
 cleanup() {
     # Remove image related resources after the test has finished
-    oc delete imagestream "operator:${TRAVIS_BUILD_NUMBER}" -n openshift
+    oc delete imagestream "runtime-operator:${TRAVIS_BUILD_NUMBER}" -n openshift
 }
 
 main() {

--- a/test/e2e/runtime_autoscaling.go
+++ b/test/e2e/runtime_autoscaling.go
@@ -69,15 +69,12 @@ func RuntimeAutoScalingTest(t *testing.T) {
 	l := fields.Set(m)
 	selec := l.AsSelector()
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}, runtimeApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeApplication.Spec.ResourceConstraints = setResources("0.2")
-	runtimeApplication.Spec.Autoscaling = setAutoScale(5, 50)
-
-	err = f.Client.Update(goctx.TODO(), runtimeApplication)
+	// Update autoscaler
+	target := types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}
+	err = util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		r.Spec.ResourceConstraints = setResources("0.2")
+		r.Spec.Autoscaling = setAutoScale(5, 50)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,16 +166,12 @@ func checkValues(hpa *autoscalingv1.HorizontalPodAutoscalerList, t *testing.T, m
 
 // Updates the values and checks they are changed
 func updateTest(t *testing.T, f *framework.Framework, runtimeApplication *runtimeappv1beta1.RuntimeApplication, options k.ListOptions, namespace string, hpa *autoscalingv1.HorizontalPodAutoscalerList) {
+	target := types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}
 
-	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}, runtimeApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeApplication.Spec.ResourceConstraints = setResources("0.2")
-	runtimeApplication.Spec.Autoscaling = setAutoScale(3, 2, 30)
-
-	err = f.Client.Update(goctx.TODO(), runtimeApplication)
+	err := util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		r.Spec.ResourceConstraints = setResources("0.2")
+		r.Spec.Autoscaling = setAutoScale(3, 2, 30)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -196,16 +189,12 @@ func updateTest(t *testing.T, f *framework.Framework, runtimeApplication *runtim
 
 // Checks when max is less than min, there should be no update
 func minMaxTest(t *testing.T, f *framework.Framework, runtimeApplication *runtimeappv1beta1.RuntimeApplication, options k.ListOptions, namespace string, hpa *autoscalingv1.HorizontalPodAutoscalerList) {
+	target := types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}
 
-	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}, runtimeApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeApplication.Spec.ResourceConstraints = setResources("0.2")
-	runtimeApplication.Spec.Autoscaling = setAutoScale(1, 6, 10)
-
-	err = f.Client.Update(goctx.TODO(), runtimeApplication)
+	err := util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		r.Spec.ResourceConstraints = setResources("0.2")
+		r.Spec.Autoscaling = setAutoScale(1, 6, 10)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,16 +212,12 @@ func minMaxTest(t *testing.T, f *framework.Framework, runtimeApplication *runtim
 
 // When min is set to less than 1, there should be no update since the minReplicas are updated to a value less than 1
 func minBoundaryTest(t *testing.T, f *framework.Framework, runtimeApplication *runtimeappv1beta1.RuntimeApplication, options k.ListOptions, namespace string, hpa *autoscalingv1.HorizontalPodAutoscalerList) {
+	target := types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}
 
-	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}, runtimeApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	runtimeApplication.Spec.ResourceConstraints = setResources("0.5")
-	runtimeApplication.Spec.Autoscaling = setAutoScale(4, 0, 20)
-
-	err = f.Client.Update(goctx.TODO(), runtimeApplication)
+	err := util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		r.Spec.ResourceConstraints = setResources("0.5")
+		r.Spec.Autoscaling = setAutoScale(4, 0, 20)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,15 +267,12 @@ func incorrectFieldsTest(t *testing.T, f *framework.Framework, ctx *framework.Te
 
 	options := k.ListOptions{FieldSelector: selec}
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-autoscaling2", Namespace: namespace}, runtimeApplication)
-	if err != nil {
-		t.Fatal(err)
-	}
+	target := types.NamespacedName{Name: "example-runtime-autoscaling", Namespace: namespace}
 
-	runtimeApplication.Spec.ResourceConstraints = setResources("0.3")
-	runtimeApplication.Spec.Autoscaling = setAutoScale(4)
-
-	err = f.Client.Update(goctx.TODO(), runtimeApplication)
+	err = util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		r.Spec.ResourceConstraints = setResources("0.3")
+		r.Spec.Autoscaling = setAutoScale(4)
+	})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/e2e/runtime_basic.go
+++ b/test/e2e/runtime_basic.go
@@ -83,14 +83,12 @@ func runtimeBasicScaleTest(t *testing.T, f *framework.Framework, ctx *framework.
 }
 
 func runtimeUpdateScaleTest(t *testing.T, f *framework.Framework, namespace string, exampleRuntime *runtimeappv1beta1.RuntimeApplication) error {
-	err := f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime", Namespace: namespace}, exampleRuntime)
-	if err != nil {
-		return err
-	}
+	target := types.NamespacedName{Name: "example-runtime", Namespace: namespace}
 
-	helper2 := int32(2)
-	exampleRuntime.Spec.Replicas = &helper2
-	err = f.Client.Update(goctx.TODO(), exampleRuntime)
+	err := util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		helper2 := int32(2)
+		r.Spec.Replicas = &helper2
+	})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runtime_probe.go
+++ b/test/e2e/runtime_probe.go
@@ -84,19 +84,13 @@ func editProbeTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx,
 	if err != nil {
 		return err
 	}
+	target := types.NamespacedName{Name: "example-runtime-readiness", Namespace: namespace}
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: "example-runtime-readiness", Namespace: namespace}, app)
-	if err != nil {
-		return err
-	}
-
-	// Adjust tests for update SMALL amounts to keep the test fast.
-	app.Spec.LivenessProbe.InitialDelaySeconds = int32(6)
-	app.Spec.ReadinessProbe.InitialDelaySeconds = int32(3)
-	err = f.Client.Update(goctx.TODO(), app)
-	if err != nil {
-		return err
-	}
+	util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		// Adjust tests for update SMALL amounts to keep the test fast.
+		r.Spec.LivenessProbe.InitialDelaySeconds = int32(6)
+		r.Spec.ReadinessProbe.InitialDelaySeconds = int32(3)
+	})
 
 	err = e2eutil.WaitForDeployment(t, f.KubeClient, namespace, "example-runtime-readiness", 1, retryInterval, timeout)
 	if err != nil {

--- a/test/e2e/runtime_pullpolicy.go
+++ b/test/e2e/runtime_pullpolicy.go
@@ -16,7 +16,6 @@ import (
 
 // RuntimePullPolicyTest checks that the configured pull policy is applied to deployment
 func RuntimePullPolicyTest(t *testing.T) {
-
 	ctx, err := util.InitializeContext(t, cleanupTimeout, retryInterval)
 	if err != nil {
 		t.Fatal(err)

--- a/test/e2e/runtime_storage.go
+++ b/test/e2e/runtime_storage.go
@@ -65,15 +65,13 @@ func updateStorageConfig(t *testing.T, f *framework.Framework, ctx *framework.Te
 		return err
 	}
 
-	err = f.Client.Get(goctx.TODO(), types.NamespacedName{Name: app.Name, Namespace: namespace}, app)
-	if err != nil {
-		return err
-	}
-	// remove storage definition to return it to a deployment
-	app.Spec.Storage = nil
-	app.Spec.VolumeMounts = nil
+	target := types.NamespacedName{Name: app.Name, Namespace: namespace}
 
-	err = f.Client.Update(goctx.TODO(), app)
+	err = util.UpdateApplication(f, target, func(r *runtimeappv1beta1.RuntimeApplication) {
+		// remove storage definition to return it to a deployment
+		r.Spec.Storage = nil
+		r.Spec.VolumeMounts = nil
+	})
 	if err != nil {
 		return err
 	}

--- a/test/e2e/runtime_test.go
+++ b/test/e2e/runtime_test.go
@@ -21,10 +21,10 @@ func TestRuntimeApplication(t *testing.T) {
 		t.Fatalf("Failed to add CR scheme to framework: %v", err)
 	}
 
-	t.Run("RuntimePullPolicyTest", RuntimePullPolicyTest)
-	t.Run("RuntimeBasicTest", RuntimeBasicTest)
-	t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
-	t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
+	// t.Run("RuntimePullPolicyTest", RuntimePullPolicyTest)
+	// t.Run("RuntimeBasicTest", RuntimeBasicTest)
+	// t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
+	// t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
 	t.Run("RuntimeProbeTest", RuntimeProbeTest)
 	t.Run("RuntimeAutoScalingTest", RuntimeAutoScalingTest)
 	t.Run("RuntimeServiceMonitorTest", RuntimeServiceMonitorTest)

--- a/test/e2e/runtime_test.go
+++ b/test/e2e/runtime_test.go
@@ -21,10 +21,10 @@ func TestRuntimeApplication(t *testing.T) {
 		t.Fatalf("Failed to add CR scheme to framework: %v", err)
 	}
 
-	// t.Run("RuntimePullPolicyTest", RuntimePullPolicyTest)
-	// t.Run("RuntimeBasicTest", RuntimeBasicTest)
-	// t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
-	// t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
+	t.Run("RuntimePullPolicyTest", RuntimePullPolicyTest)
+	t.Run("RuntimeBasicTest", RuntimeBasicTest)
+	t.Run("RuntimeStorageTest", RuntimeBasicStorageTest)
+	t.Run("RuntimePersistenceTest", RuntimePersistenceTest)
 	t.Run("RuntimeProbeTest", RuntimeProbeTest)
 	t.Run("RuntimeAutoScalingTest", RuntimeAutoScalingTest)
 	t.Run("RuntimeServiceMonitorTest", RuntimeServiceMonitorTest)


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Adds wrapper method to update runtime applications, retrying for 30 seconds before erroring out. There seems to be times where small changes occur in the CR, such as status updates, that prevent tests from updating the application. This should stop those cases from erroring.
- Removed a conditional from service monitor test that throws a lot of errors, seemed unnecessary but can be re-added if that's not the case.

**Which issue(s) this PR fixes**:
<!--
Automatically closes the linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

If you don't want any issue to get closed when this PR is merged,
then add `Fixes #<issue number>` in a comment instead and remove the next line.
-->
Fixes #15 
