### PR TITLE
Add additional labels/annotations for OpenShift support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,5 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Changed the default labels that are created by the operator, to better
+  accommodate components that are being deployed onto OpenShift. ([#21](https://github.com/application-stacks/operator/pull/21))

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -158,7 +158,7 @@ for an `RuntimeApplication` CR:
 | `app.kubernetes.io/name`       | `metadata.name`                | A name that represents this component.                                                                                                               |
 | `app.kubernetes.io/managed-by` | `application-runtime-operator` | The tool being used to manage this component.                                                                                                                |
 | `app.kubernetes.io/component`  | `backend`                      | The type of component being created. See OpenShift [documentation](https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc#labels) for full list. |
-| `app.kubernetes.io/part-of`    | `metadata.name`                | The service that this component belongs to. Configure this if the component is not a standalone application. |
+| `app.kubernetes.io/part-of`    | `metadata.name`                | The name of the higher-level application this component is a part of. Configure this if the component is not a standalone application. |
 | `app.kubernetes.io/version`    | `version`                      | The version of the component.                                                                                                                                |
 
 You can set new labels in addition to the pre-existing ones or overwrite them,

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -149,7 +149,21 @@ If applications require specific permissions but still want the operator to crea
 
 ### Labels
 
-By default, the operator adds the following labels into all resources created for an `RuntimeApplication` CR: `app.kubernetes.io/instance`, `app.kubernetes.io/name`, `app.kubernetes.io/managed-by`, `app.kubernetes.io/version` (when `version` is defined). You can set new labels in addition to the pre-existing ones or overwrite them, excluding the `app.kubernetes.io/instance` label. To set labels, specify them in your CR as key/value pairs.
+By default, the operator adds the following labels into all resources created
+for an `RuntimeApplication` CR: 
+
+| Label                          | Default                        | Description                                                                                                                                                  |
+|--------------------------------|--------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `app.kubernetes.io/instance`   | `metadata.name`                | A unique name or identifier for this component. This cannot be modified.                                                                                                                 |
+| `app.kubernetes.io/name`       | `metadata.name`                | A name that represents this component.                                                                                                               |
+| `app.kubernetes.io/managed-by` | `application-runtime-operator` | The tool being used to manage this component.                                                                                                                |
+| `app.kubernetes.io/component`  | `backend`                      | The type of component being created. See OpenShift [documentation](https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc#labels) for full list. |
+| `app.kubernetes.io/part-of`    | `metadata.name`                | The service that this component belongs to. Configure this if the component is not a standalone application. |
+| `app.kubernetes.io/version`    | `version`                      | The version of the component.                                                                                                                                |
+
+You can set new labels in addition to the pre-existing ones or overwrite them,
+excluding the `app.kubernetes.io/instance` label. To set labels, specify them in
+your CR as key/value pairs.
 
 ```yaml
 apiVersion: runtime.app/v1beta1
@@ -163,6 +177,11 @@ spec:
 ```
 
 _After the initial deployment of `RuntimeApplication`, any changes to its labels would be applied only when one of the parameters from `spec` is updated._
+
+#### OpenShift Labels
+
+When running in OpenShift, there are additional labels and annotations that are
+standard on the platform. See OpenShift [documentation]() for a full list.
 
 ### Annotations
 

--- a/doc/user-guide.md
+++ b/doc/user-guide.md
@@ -178,10 +178,11 @@ spec:
 
 _After the initial deployment of `RuntimeApplication`, any changes to its labels would be applied only when one of the parameters from `spec` is updated._
 
-#### OpenShift Labels
+#### OpenShift Recommended Labels
 
 When running in OpenShift, there are additional labels and annotations that are
-standard on the platform. See OpenShift [documentation]() for a full list.
+standard on the platform. It is recommended that you overwrite our defaults
+where applicable and add any labels from the list that are not set by default using the above instructions. See [documentation](https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc#labels) for a full list.
 
 ### Annotations
 
@@ -199,6 +200,13 @@ spec:
 ```
 
 _After the initial deployment of `RuntimeApplication`, any changes to its annotations would be applied only when one of the parameters from `spec` is updated._
+
+#### OpenShift Recommended Annotations
+
+When running in OpenShift, there are additional annotations that are
+standard on the platform. It is recommended that you overwrite our defaults
+where applicable and add any annotations from the list that are not set by
+default using the above instructions. See [documentation](https://github.com/gorkem/app-labels/blob/master/labels-annotation-for-openshift.adoc#labels) for a full list.
 
 ### Environment variables
 

--- a/pkg/apis/runtimeapp/v1beta1/runtimeapplication_types.go
+++ b/pkg/apis/runtimeapp/v1beta1/runtimeapplication_types.go
@@ -583,11 +583,12 @@ func (cr *RuntimeApplication) Initialize() {
 
 // GetLabels returns set of labels to be added to all resources
 func (cr *RuntimeApplication) GetLabels() map[string]string {
-
 	labels := map[string]string{
 		"app.kubernetes.io/instance":   cr.Name,
 		"app.kubernetes.io/name":       cr.Name,
 		"app.kubernetes.io/managed-by": "application-runtime-operator",
+		"app.kubernetes.io/component": "backend",
+		"app.kubernetes.io/part-of": cr.Name,
 	}
 
 	if cr.Spec.Version != "" {


### PR DESCRIPTION
**What this PR does / why we need it?**:

- See [#175](https://github.com/appsody/appsody-operator/issues/175) from appsody for details on why these labels are necessary.
- Added two new labels `app.kubernetes.io/part-of` (defaulting to the app name), and `app.kubernetes.io/component` (defaulting to "backend").
  - This would include all recommend labels, of the optional ones I did not see any others currently missing that we would have information about in application-stacks operator.
  - I was not able to add the recommended annotations from the above link here, as they corresponded to git repository information which, to my understanding, we do not have information on in any scenario with this operator. (If we want them anyways with the default `unknown` I can add that)

**Does this PR introduce a user-facing change?**
<!--
If this PR introduces a user-facing change, it must include sufficient documentation to explain the use of the new or updated feature in addition to a summary of the change and link to the pull request.
-->
- [x] User guide
- [x] `CHANGELOG.md`

