### PR TITLE
Improve travis stages for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,20 +13,25 @@ services:
 stages:
   - name: test
   - name: build
+    if: branch = master AND fork = false AND type != pull_request
   - name: build manifest
+    if: branch = master AND fork = false AND type != pull_request
 
 jobs:
   include:
     - name: Unit testing
-      script:
-        - make unit-test
+      stage: test
+      os: linux
+      arch:
+        - amd64
+        - ppc64le
+        - s390x
+      script: make unit-test
     - name: Verify operator image build
-      script:
-        - make build-image
+      script: make build-image
       if: branch != master OR fork = true OR type = pull_request
     - name: E2E testing
-      script:
-        - make test-e2e
+      script: make test-e2e
       if: fork = false
     ## if master branch build and push images on all three archs
     ## the below will all run in parallel as they're the same stage
@@ -37,27 +42,20 @@ jobs:
       script:
         - make build-multiarch-image
         - make build-manifest
-      if: branch = master AND fork = false AND type != pull_request
     - name: Build image on ppc64le
-      stage: build
       os: linux
       arch: ppc64le
       script:
         - make build-multiarch-image
         - make build-manifest
-      if: branch = master AND fork = false AND type != pull_request
     - name: Build image on s390x
-      stage: build
       os: linux
       arch: s390x
       script:
         - make build-multiarch-image
         - make build-manifest
-      if: branch = master AND fork = false AND type != pull_request
     ## in case there were concurrency issues with building manifest lists
     ## in previous steps, create FAT manifests one last time
     - name: Verify manifest lists
       stage: build manifest
-      script:
-        - make build-manifest
-      if: branch = master AND fork = false AND type != pull_request
+      script: make build-manifest

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,6 @@ jobs:
   include:
     - name: Unit testing
       stage: test
-      os: linux
-      arch:
-        - amd64
-        - ppc64le
-        - s390x
       script: make unit-test
     - name: Verify operator image build
       script: make build-image
@@ -34,7 +29,6 @@ jobs:
       script: make test-e2e
       if: fork = false
     ## if master branch build and push images on all three archs
-    ## the below will all run in parallel as they're the same stage
     - name: Build image on amd64
       stage: build
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,16 @@ stages:
 jobs:
   include:
     - name: Unit testing
-      stage: test
       script:
         - make unit-test
-    - name: Build image and E2E test
+    - name: Verify operator image build
+      script:
+        - make build-image
+      if: branch != master OR fork = true OR type = pull_request
+    - name: E2E testing
       script:
         - make test-e2e
+      if: fork = false
     ## if master branch build and push images on all three archs
     ## the below will all run in parallel as they're the same stage
     - name: Build image on amd64


### PR DESCRIPTION
**What this PR does / why we need it?**:

- Don't run E2E tests on forks, as they will not have access to the build secrets required.
- Conditionally run the image build stage separate to the E2E tests (when not master branch), now that E2E doesn't always run for all builds.
